### PR TITLE
Correctly save proxied requests from mapi only if miner accepted the tx (or if checkstatus:true is set)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1338,6 +1338,15 @@ For example, set the following HTTP headers to attach additional information:
 
 `tags`: `["animals", "bitcoin"]`
 
+When pushing a tx (POST /mapi/tx) you might want to check if the transaction was confirmed long ago and then force it to be saved:
+
+`checkstatus`: `true`
+
+If you do not set `checkstatus: true` when attempting to broadcast a really old (but confirmed) transaction, then TXQ will not save it in the
+database because the Merchant API returns `ERROR: Missing inputs`.  This is because of course miners may not keep old transactions (ie: prune)
+and therefore we must have a way to first check whether the transaction is confirmed long ago.
+
+Set `checkstatus` to indicate to TXQ to do a "pre-flight" check with `statustx` to know whether we should save this confirmed transaction or not despite whether the push broadcast returns `ERROR: Missing inputs` or not.
 
 ### Query Primary Miner Merchant API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "txq",
-  "version": "1.4.16",
+  "version": "1.4.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "txq",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "description": "TXQ: Bitcoin Transaction Storage Queue Service",
   "main": "src/bootstrap/index",
   "license": "MIT",

--- a/src/services/helpers/ChannelMetaUtil.ts
+++ b/src/services/helpers/ChannelMetaUtil.ts
@@ -1,0 +1,31 @@
+import { Request } from "express";
+
+export class ChannelMetaUtil {
+    static getChannnelMeta(userReq: Request): { channel: string, metadata: any, tags: any } {
+        let channel = undefined;
+        let metadata = undefined;
+        let tags = undefined;
+        if (userReq.headers && userReq.headers.channel) {
+          channel = userReq.headers.channel
+        }
+        if (userReq.headers && userReq.headers.metadata) {
+          try {
+            let tmpMetadata: any = userReq.headers.metadata;
+            metadata = JSON.parse(tmpMetadata);
+          } catch (ex) {
+          }
+        }
+        if (userReq.headers && userReq.headers.tags) {
+          try {
+            let tmpTags: any = userReq.headers.tags;
+            tags = JSON.parse(tmpTags);
+          } catch (ex) {
+          }
+        }
+        return {
+          channel,
+          metadata,
+          tags
+        };
+    }
+}

--- a/src/services/helpers/MerchantRequestor.ts
+++ b/src/services/helpers/MerchantRequestor.ts
@@ -2,6 +2,7 @@
 import * as Minercraft from 'minercraft';
 import { IMerchantConfig, IMerchantApiEndpointConfig } from '@interfaces/IConfig';
 import * as bsv from 'bsv';
+import { MerchantapilogEventTypes } from '../merchantapilog';
 
 /**
  * A policy interface for how to execute broadcasts against merchantapi endpoints
@@ -55,7 +56,7 @@ export class MerchantRequestorSendPolicySerialBackup extends MerchantRequestorPo
           });
 
           if (this.responseSaver) {
-            await this.responseSaver(this.endpoints[i].name, 'pushtx', response, params.txid);
+            await this.responseSaver(this.endpoints[i].name, MerchantapilogEventTypes.PUSHTX, response, params.txid);
           }
 
           if (response && response.payload && response.payload.returnResult === 'success') {
@@ -67,7 +68,7 @@ export class MerchantRequestorSendPolicySerialBackup extends MerchantRequestorPo
           }
         } catch (err) {
           if (this.responseSaver) {
-            await this.responseSaver(this.endpoints[i].name, 'pushtx', { error: err.toString(), stack: err.stack }, params.txid);
+            await this.responseSaver(this.endpoints[i].name, MerchantapilogEventTypes.PUSHTX, { error: err.toString(), stack: err.stack }, params.txid);
           }
           this.logError('MerchantRequestorSendPolicySerialBackup', { error: err.toString(), stack: err.stack });
           errors.push(err.toString());
@@ -100,7 +101,7 @@ export class MerchantRequestorStatusPolicySerialBackup extends MerchantRequestor
           const response = await miner.tx.status(params.txid, {verbose: true});
 
           if (this.responseSaver) {
-            await this.responseSaver(this.endpoints[i].name, 'statustx', response, params.txid);
+            await this.responseSaver(this.endpoints[i].name, MerchantapilogEventTypes.STATUSTX, response, params.txid);
           }
 
           if (response && response.payload && response.payload.returnResult === 'success') {
@@ -113,7 +114,7 @@ export class MerchantRequestorStatusPolicySerialBackup extends MerchantRequestor
         } catch (err) {
 
           if (this.responseSaver) {
-            await this.responseSaver(this.endpoints[i].name, 'statustx', { error: err.toString(), stack: err.stack }, params.txid);
+            await this.responseSaver(this.endpoints[i].name, MerchantapilogEventTypes.STATUSTX, { error: err.toString(), stack: err.stack }, params.txid);
           }
 
           this.logError('MerchantRequestorStatusPolicySerialBackup',{ error: err.toString(), stack: err.stack } );
@@ -164,7 +165,7 @@ export class MerchantRequestorSendPolicySendAllTakeFirstPrioritySuccess extends 
             }
           } catch (err) {
             if (this.responseSaver) {
-              await this.responseSaver(this.endpoints[i].name, 'statustx', { error: err.toString(), stack: err.stack }, params.txid);
+              await this.responseSaver(this.endpoints[i].name, MerchantapilogEventTypes.STATUSTX, { error: err.toString(), stack: err.stack }, params.txid);
             }
             this.logError('MerchantRequestorSendPolicySerialBackup', { error: err.toString(), stack: err.stack });
             errors.push(err.toString());
@@ -181,7 +182,7 @@ export class MerchantRequestorSendPolicySendAllTakeFirstPrioritySuccess extends 
         this.logInfo('minerResult', {url: this.endpoints[i].url, result: minerBroadcastResult[i]});
         // Save to database if logging enabled
         if (this.responseSaver) {
-          await this.responseSaver(this.endpoints[i].name, 'pushtx', minerBroadcastResult[i], params.txid);
+          await this.responseSaver(this.endpoints[i].name, MerchantapilogEventTypes.PUSHTX, minerBroadcastResult[i], params.txid);
         }
         // Get the authoratative success result
         // Keep the first success always

--- a/src/services/helpers/StatusTxUtil.ts
+++ b/src/services/helpers/StatusTxUtil.ts
@@ -1,0 +1,46 @@
+import { BitcoinRegex } from "./BitcoinRegex";
+
+export class StatusTxUtil {
+
+    static isAcceptedStatus(statusObj: any): boolean {
+        const isValid = statusObj && statusObj.payload &&
+        statusObj.payload.returnResult === 'success' &&
+        statusObj.payload.blockHeight >= 0 &&
+        statusObj.payload.confirmations >= 0 && statusObj.valid;
+        return isValid;
+    }
+
+    static isAcceptedPush(status: any): boolean {
+        try {
+            const payload = JSON.parse(status.payload);
+            const txRegex = new RegExp(BitcoinRegex.TXID_REGEX);
+            return StatusTxUtil.isAcceptedBeforePush(status) || (
+                payload &&
+                payload.returnResult === 'success' &&
+                txRegex.test(payload.txid)
+            );
+        } catch (err) {
+            ;
+        }
+        return false;
+    }
+
+    static isAcceptedBeforePush(status: any): boolean {
+        if (!status || !status.payload) {
+            return false;
+        }
+        try {
+            const payload = JSON.parse(status.payload);
+            const isValid = payload &&
+                payload.returnResult === 'failure' &&
+                (
+                    payload.resultDescription === 'ERROR: Transaction already in the mempool' ||
+                    payload.resultDescription  === 'ERROR: 257: txn-already-known'
+                )
+            return isValid;
+        } catch (err) {
+            ;
+        }
+        return false;
+    }
+}

--- a/src/services/merchantapilog/index.ts
+++ b/src/services/merchantapilog/index.ts
@@ -1,5 +1,15 @@
 import { Service, Inject } from 'typedi';
 
+export enum MerchantapilogEventTypes {
+  PUSHTX = 'pushtx',
+  STATUSTX = 'statustx',
+  PROXYPUSHTX = 'proxypushtx',
+  PROXYSTATUSTX = 'proxystatustx',
+  CHECKPUSHTX = 'checkpushtx',
+  PROXYFEEQUOTE = 'proxyfeequote',
+  FEEQUOTE = 'feequote',
+}
+
 @Service('merchantapilogService')
 export default class MerchantapilogService {
   constructor(

--- a/src/services/tx/index.ts
+++ b/src/services/tx/index.ts
@@ -15,7 +15,6 @@ export default class TxService {
 
   public async getTx(txid: string, rawtx?: boolean) {
     let tx = await this.txModel.getTx(txid, rawtx);
-
     if (!tx) {
       throw new ResourceNotFoundError();
     }

--- a/src/services/use_cases/proxy/ProxyAndSaveRequestIfCheckStatus.ts
+++ b/src/services/use_cases/proxy/ProxyAndSaveRequestIfCheckStatus.ts
@@ -1,0 +1,143 @@
+
+import { Service, Inject } from 'typedi';
+import { UseCase } from '../UseCase';
+import { UseCaseOutcome } from '../UseCaseOutcome';
+import Config from '../../../cfg';
+import { MerchantRequestor } from '../../../services/helpers/MerchantRequestor';
+import * as bsv from 'bsv';
+import * as express from 'express';
+import { MerchantapilogEventTypes } from '../../../services/merchantapilog';
+import { StatusTxUtil } from '../../../services/helpers/StatusTxUtil';
+import { ChannelMetaUtil } from '../../../services/helpers/ChannelMetaUtil';
+
+@Service('proxyAndSaveRequestIfCheckStatus')
+export default class ProxyAndSaveRequestIfCheckStatus extends UseCase {
+  constructor(
+    @Inject('merchantapilogService') private merchantapilogService,
+    @Inject('saveProxyRequestResponse') private saveProxyRequestResponse,
+    @Inject('saveTxs') private saveTxs,
+    @Inject('logger') private logger) {
+    super();
+  }
+   /**
+   * Hold up the broadcast request and first check if we have the transaction already
+   * If the transaction appears in the blockchain, then it means we should store the transaction immediately
+   *
+   * @param req Request to determine if we should check status first and save the tx if needed
+   * @param cb
+   */
+  async run(params: {
+    req: express.Request,
+    cb: Function
+  }): Promise<UseCaseOutcome> {
+    try {
+      // Check if it's a broadcast attempt
+      if (/^post$/i.test(params.req.method) &&
+          /^\/tx$/i.test(params.req.path) && this.hasCheckStatusSet(params.req)) {
+        // Decode the transaction to get the txid we can use to query
+        let tx;
+        try {
+           tx = new bsv.Transaction(params.req.body.rawtx || params.req.body.rawTx);
+        } catch (decodeError) {
+          this.logger.debug('proxyAndSaveRequestIfCheckStatus', {
+            decodeError
+          });
+        }
+        if (tx) {
+          try {
+            await this.processTransactionStatus(tx, ChannelMetaUtil.getChannnelMeta(params.req));
+          } catch (processTransactionStatusError) {
+           this.logger.debug('proxyAndSaveRequestIfCheckStatus', {
+            processTransactionStatusError
+           });
+         }
+        }
+      }
+      if (params && params.cb) {
+        params.cb();
+      }
+      return {
+        success: true,
+        result: {
+        }
+      };
+    } catch (ex) {
+      if (params && params.cb) {
+        params.cb();
+      }
+      throw ex;
+    }
+  }
+  /**
+   * Determine if the transaction was already settled long ago, if so then save it to our database.
+   * This is needed because an error "inputs missing" is returned when attempting to broadcast and already confirmed very old transaction.
+   *
+   * The approach below is to first call GET /mapi/tx/:txid to see if it was settled long ago before.
+   * If it was then store the tx in the database.
+   *
+   * If we didnt do this, then any broadcast transactions to mapi would not get saved to TXQ.
+   *
+   *
+   * @param tx Transaction to check status for and save to the db
+   */
+  async processTransactionStatus(tx: bsv.Transaction, channelMeta: any) {
+    /**
+     * Save the response callback
+     *
+     * Since we use this only for 'push check status', then rewrite the eventType to 'pushcheckstatustx'
+     *
+     * @param miner Miner to save under
+     * @param eventType Event type
+     * @param response Response to save
+     * @param txid Given txid or null
+     */
+    const saveResponseTask = async  (miner: string, eventType: string, response: any, txid: string) => {
+      if (Config.merchantapi.enableResponseLogging) {
+        this.logger.info('saveResponseTask', {
+          miner,  txid
+        });
+        await this.merchantapilogService.save(miner, MerchantapilogEventTypes.CHECKPUSHTX, response, txid);
+      }
+      return true;
+    };
+    const merchantRequestor = new MerchantRequestor(
+      { ... Config.merchantapi },
+      null,
+      saveResponseTask
+    )
+    let status = await merchantRequestor.statusTx(tx.hash);
+    // Check whether the transaction was settled (confirmed) at some point
+    // We want to save the tx if and only if it was confirmed because
+    // that way we know it is valid and committed.
+    // If we accepted non-confirmed, then we could pollute database with unconfirmed/invalid tx.
+    if (StatusTxUtil.isAcceptedStatus(status)) {
+        const txid = tx.hash || undefined;
+        await this.saveTxs.run({
+          channel: channelMeta.channel ? channelMeta.channel : null,
+          set: {
+            [txid]: {
+              rawtx: tx.toString(),
+              metadata: channelMeta.metadata,
+              tags: channelMeta.tags
+            }
+          }
+        });
+    }
+    return status;
+  }
+
+  /**
+   * Whether we should check status first before broadcasting
+   * @param req Request to check for 'checkstatus' in header or query param
+   */
+  hasCheckStatusSet(req: express.Request) {
+    if (req.query.checkstatus && req.query.checkstatus === 'true') {
+      return true;
+    }
+    if (req.headers && req.headers.checkstatus === 'true') {
+      return true;
+    }
+    return false;
+  }
+}
+


### PR DESCRIPTION
Problem:

If a bad tx is broadcast via /mapi, then before it would always save the tx into the database even if it is corrupted (ie: a miner. will not or has not accepted it)

Therefore the solution is to inspect the response payload and only save to the database if:

- The transaction was already confirmed before
- The transaction is stated to be 'already known' or 'in the mempool'.

Also introduce `checkstatus:true` for header or query url param for POST /mapi/tx to force the proxy to first check if the transaction is an old (but confirmed) transaction.  This way we can broadcast really old transactions that give 'missing inputs' error, but yet are known to be settled.

