### PR TITLE
Add address scripthash txid query

### DIFF
--- a/src/api/v1/channel/index.ts
+++ b/src/api/v1/channel/index.ts
@@ -23,7 +23,10 @@ export default [
             limit: Req.query.limit ? Req.query.limit : 1000,
             rawtx: Req.query.rawtx === '1' ? true : false,
             status: Req.query.status || 'all',
-            accountContext: AccountContextHelper.getContext(Req)
+            accountContext: AccountContextHelper.getContext(Req),
+            address: Req.query.address || '',
+            scripthash: Req.query.scripthash || '',
+            txid: Req.query.txid || '',
           });
           sendResponseWrapper(Req, res, 200, data.result);
         } catch (error) {
@@ -53,7 +56,10 @@ export default [
             limit: Req.query.limit ? Req.query.limit : 1000,
             rawtx: Req.query.rawtx === '1' ? true : false,
             status: Req.query.status || 'all',
-            accountContext: AccountContextHelper.getContext(Req)
+            accountContext: AccountContextHelper.getContext(Req),
+            address: Req.query.address || '',
+            scripthash: Req.query.scripthash || '',
+            txid: Req.query.txid || '',
           });
           sendResponseWrapper(Req, res, 200, data.result);
         } catch (error) {

--- a/src/api/v1/channel/index.ts
+++ b/src/api/v1/channel/index.ts
@@ -7,6 +7,9 @@ import ResourceNotFoundError from '../../../services/error/ResourceNotFoundError
 import { sendErrorWrapper } from '../../../util/sendErrorWrapper';
 import { AccountContextHelper } from '../../account-context-helper';
 import AccessForbiddenError from '../../../services/error/AccessForbiddenError';
+import { ChannelHelper } from '../../../services/helpers/ChannelHelper';
+import InvalidAddressError from '../../../services/error/InvalidAddressError';
+import InvalidScriptHashOrTXIDError from '../../../services/error/InvalidScriptHashOrTXIDError';
 
 export default [
   {
@@ -24,9 +27,21 @@ export default [
             rawtx: Req.query.rawtx === '1' ? true : false,
             status: Req.query.status || 'all',
             accountContext: AccountContextHelper.getContext(Req),
-            address: Req.query.address || '',
-            scripthash: Req.query.scripthash || '',
-            txid: Req.query.txid || '',
+            addresses: ChannelHelper.checkAddresses(
+              ChannelHelper.getParamStringArray(
+                (Req.query.address as string | string[]) || [],
+              ),
+            ),
+            scripthashes: ChannelHelper.checkScriptHashesOrTXIDs(
+              ChannelHelper.getParamStringArray(
+                (Req.query.scripthash as string | string[]) || [],
+              ),
+            ),
+            txids: ChannelHelper.checkScriptHashesOrTXIDs(
+              ChannelHelper.getParamStringArray(
+                (Req.query.txid as string | string[]) || [],
+              ),
+            ),
           });
           sendResponseWrapper(Req, res, 200, data.result);
         } catch (error) {
@@ -35,6 +50,9 @@ export default [
             return;
           } else if (error instanceof AccessForbiddenError) {
             sendErrorWrapper(res, 403, error.toString());
+            return;
+          } else if (error instanceof InvalidAddressError || error instanceof InvalidScriptHashOrTXIDError) {
+            sendErrorWrapper(res, 400, error.toString());
             return;
           }
           next(error);
@@ -57,9 +75,21 @@ export default [
             rawtx: Req.query.rawtx === '1' ? true : false,
             status: Req.query.status || 'all',
             accountContext: AccountContextHelper.getContext(Req),
-            address: Req.query.address || '',
-            scripthash: Req.query.scripthash || '',
-            txid: Req.query.txid || '',
+            addresses: ChannelHelper.checkAddresses(
+              ChannelHelper.getParamStringArray(
+                (Req.query.address as string | string[]) || [],
+              ),
+            ),
+            scripthashes: ChannelHelper.checkScriptHashesOrTXIDs(
+              ChannelHelper.getParamStringArray(
+                (Req.query.scripthash as string | string[]) || [],
+              ),
+            ),
+            txids: ChannelHelper.checkScriptHashesOrTXIDs(
+              ChannelHelper.getParamStringArray(
+                (Req.query.txid as string | string[]) || [],
+              ),
+            ),
           });
           sendResponseWrapper(Req, res, 200, data.result);
         } catch (error) {
@@ -68,6 +98,9 @@ export default [
             return;
           } else if (error instanceof AccessForbiddenError) {
             sendErrorWrapper(res, 403, error.toString());
+            return;
+          } else if (error instanceof InvalidAddressError || error instanceof InvalidScriptHashOrTXIDError) {
+            sendErrorWrapper(res, 400, error.toString());
             return;
           }
           next(error);

--- a/src/services/error/InvalidAddressError.ts
+++ b/src/services/error/InvalidAddressError.ts
@@ -1,0 +1,5 @@
+export default class InvalidAddressError extends Error {
+  toString() {
+      return  'InvalidAddressError';
+  }
+}

--- a/src/services/error/InvalidScriptHashOrTXIDError.ts
+++ b/src/services/error/InvalidScriptHashOrTXIDError.ts
@@ -1,0 +1,5 @@
+export default class InvalidScriptHashOrTXIDError extends Error {
+  toString() {
+      return  'InvalidScriptHashOrTXIDError';
+  }
+}

--- a/src/services/helpers/ChannelHelper.ts
+++ b/src/services/helpers/ChannelHelper.ts
@@ -1,0 +1,49 @@
+import * as bsv from 'bsv';
+import InvalidAddressError from '../error/InvalidAddressError';
+import InvalidScriptHashOrTXIDError from '../error/InvalidScriptHashOrTXIDError';
+
+export class ChannelHelper {
+  public static getParamStringArray(param: string | string[]): string[] {
+    return Array.isArray(param) ? param : param.split(',');
+  }
+
+  public static checkAddresses(addresses: string[]): string[] {
+    if (addresses.length === 0) {
+      return addresses;
+    }
+
+    const invalidAddresses = addresses.filter(address => {
+      try {
+        const bsvAddress = new bsv.Address(address);
+        bsvAddress.toString();
+        return false; 
+      } catch (_) {
+        return true;
+      }
+    });
+    
+    if (invalidAddresses.length > 0) {
+      throw new InvalidAddressError();
+    }
+
+    return addresses;
+  }
+
+  public static checkScriptHashesOrTXIDs(items: string[]): string[] {
+    if (items.length === 0) {
+      return items;
+    }
+    
+    const regexp = /^[0-9a-fA-F]+$/;
+
+    const invalidItems = items.filter(item => {
+      return (regexp.test(item) && Buffer.byteLength(item, "hex") === 32) ? false : true;
+    });
+
+    if (invalidItems.length > 0) {
+      throw new InvalidScriptHashOrTXIDError();
+    }
+
+    return items;
+  }
+}

--- a/src/services/txmeta/index.ts
+++ b/src/services/txmeta/index.ts
@@ -15,8 +15,8 @@ export default class TxmetaService {
     return tx;
   }
 
-  public async getTxsByChannel(accountContext: IAccountContext, channel: string, afterId: number, limit: number, status: TransactionStatusType, rawtx?: boolean) {
-    return this.txmetaModel.getTxsByChannel(accountContext, channel, afterId, limit, status, rawtx);
+  public async getTxsByChannel(accountContext: IAccountContext, channel: string, afterId: number, limit: number, status: TransactionStatusType, addresses: string[], scripthashes: string[], txids: string[], rawtx?: boolean) {
+    return this.txmetaModel.getTxsByChannel(accountContext, channel, afterId, limit, status, addresses, scripthashes, txids, rawtx);
   }
 
   public async saveTxmeta(accountContext: IAccountContext, txid: string, channel: string | undefined | null, txmeta: ITransactionMeta, tags: any, extracted: any) {

--- a/src/services/use_cases/tx/GetTxsByChannel.ts
+++ b/src/services/use_cases/tx/GetTxsByChannel.ts
@@ -18,7 +18,10 @@ export default class GetTxsDlq extends UseCase {
     limit: any,
     rawtx: boolean,
     status: any,
-    accountContext?: IAccountContext
+    accountContext?: IAccountContext,
+    address: string | string[],
+    scripthash: string | string[],
+    txid: string | string[],
   }): Promise<UseCaseOutcome> {
     let txs = await this.txmetaService.getTxsByChannel(params.accountContext, params.channel, params.id, params.limit, params.status, params.rawtx);
     return {

--- a/src/services/use_cases/tx/GetTxsByChannel.ts
+++ b/src/services/use_cases/tx/GetTxsByChannel.ts
@@ -19,11 +19,11 @@ export default class GetTxsDlq extends UseCase {
     rawtx: boolean,
     status: any,
     accountContext?: IAccountContext,
-    address: string | string[],
-    scripthash: string | string[],
-    txid: string | string[],
+    addresses: string[],
+    scripthashes: string[],
+    txids: string[],
   }): Promise<UseCaseOutcome> {
-    let txs = await this.txmetaService.getTxsByChannel(params.accountContext, params.channel, params.id, params.limit, params.status, params.rawtx);
+    let txs = await this.txmetaService.getTxsByChannel(params.accountContext, params.channel, params.id, params.limit, params.status, params.addresses, params.scripthashes, params.txids, params.rawtx);
     return {
       success: true,
       result: txs


### PR DESCRIPTION
- Added addresses, scripthashes and txids query for transactions
- It's creating an array for the existing addresses and scripthashes
- Accepting one or more values per param (separated by comma)